### PR TITLE
Converted error message to string after property undefined error

### DIFF
--- a/h5bp/Cakefile
+++ b/h5bp/Cakefile
@@ -92,7 +92,8 @@ task = (name, description, action) ->
 #
 #     return error new Error(':((') if err
 error = (err) ->
-  console.error '  ✗ '.red + err.message.red
+  err_msg = err.message + ''
+  console.error '  ✗ '.red + err_msg.red
   process.exit 1
 
 


### PR DESCRIPTION
We can't do `err.msg.red` because it looks for the `.red` property from the object.  We must do a string conversion such as `err_msg = err.msg + ''`.  Other suggestions are welcome.
